### PR TITLE
price aggregator init function consistency

### DIFF
--- a/mandos/init-price-aggregator.scen.json
+++ b/mandos/init-price-aggregator.scen.json
@@ -51,9 +51,12 @@
                 "contractCode": "file:../price-aggregator/output/price-aggregator.wasm",
                 "value": "0",
                 "arguments": [
-                    "address:oracle1|address:oracle2|address:oracle3|address:oracle4",
                     "3",
-                    "2"
+                    "2",
+                    "address:oracle1",
+                    "address:oracle2",
+                    "address:oracle3",
+                    "address:oracle4"
                 ],
                 "gasLimit": "1,000,000,000",
                 "gasPrice": "0"

--- a/mandos/price-aggregator.scen.json
+++ b/mandos/price-aggregator.scen.json
@@ -114,6 +114,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "storage": {
+                        "str:was_contract_deployed": "1",
                         "str:decimals": "2",
                         "str:submission_count": "3",
                         "str:oracle_status.info": "u32:4|u32:1|u32:4|u32:4",
@@ -264,6 +265,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "storage": {
+                        "str:was_contract_deployed": "1",
                         "str:decimals": "2",
                         "str:submission_count": "3",
                         "str:oracle_status.info": "u32:4|u32:1|u32:4|u32:4",
@@ -363,6 +365,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "storage": {
+                        "str:was_contract_deployed": "1",
                         "str:decimals": "2",
                         "str:submission_count": "3",
                         "str:oracle_status.info": "u32:4|u32:1|u32:4|u32:4",


### PR DESCRIPTION
Init function consistency on upgrade. 

- A flag is kept in storage instead of using `set_if_empty`, since `0` for `decimals` will return empty == true, so if the contract was using 0 decimals for whatever reason, this would be overwritten even with `set_if_empty`
- make sure Oracle status is not overwritten on upgrade
- use var args instead of a single argument for oracles