### PR TITLE
check submission count

### DIFF
--- a/mandos/price-aggregator.scen.json
+++ b/mandos/price-aggregator.scen.json
@@ -416,13 +416,38 @@
         },
         {
             "step": "scCall",
-            "txId": "remove-oracle",
+            "txId": "remove-oracle-invalid-submission-count",
             "tx": {
                 "from": "address:aggregator_owner",
                 "to": "sc:price_aggregator_smart_contract",
                 "value": "0",
                 "function": "removeOracles",
                 "arguments": [
+                    "3",
+                    "address:oracle1",
+                    "address:oracle3"
+                ],
+                "gasLimit": "100,000,000",
+                "gasPrice": "0"
+            },
+            "expect": {
+                "status": "4",
+                "message": "str:Invalid submission count",
+                "out": [],
+                "gas": "*",
+                "refund": "*"
+            }
+        },
+        {
+            "step": "scCall",
+            "txId": "remove-oracle-ok",
+            "tx": {
+                "from": "address:aggregator_owner",
+                "to": "sc:price_aggregator_smart_contract",
+                "value": "0",
+                "function": "removeOracles",
+                "arguments": [
+                    "2",
                     "address:oracle1",
                     "address:oracle3"
                 ],


### PR DESCRIPTION
- add checks for the `submission_count` value on init and when oracles are removed
- change `submission_count` type from `u32` to `usize` (usize is always 32 bits in smart contracts, but this makes the code not have to constantly rely on `as` to convert between the two types)